### PR TITLE
Adopt the regex! macro

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -54,14 +54,12 @@ pub fn make_conn(path: &Path) -> DbConn {
 
 #[cfg(debug_assertions)]
 fn db_trace(event: TraceEvent) {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwrap());
+    use regex::regex;
 
     if let TraceEvent::Profile(stmt, duration) = event {
         trace!(
             "sqlite: {} ({:.3}s)",
-            RE.replace_all(&stmt.sql(), " "),
+            regex!(r"\s+").replace_all(&stmt.sql(), " "),
             duration.as_secs_f32()
         );
     }

--- a/src/data/player.rs
+++ b/src/data/player.rs
@@ -8,16 +8,18 @@ use super::{Award, BashoId, Heya, Rank, Result};
 use crate::external::{discord, AuthProvider, ImageSize, UserInfo};
 use askama::Template;
 use rand::random;
-use regex::{Regex, RegexBuilder};
+use regex::{regex, Regex};
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
-use std::sync::LazyLock;
 use url::Url;
 
 pub type PlayerId = i64;
 
 pub const NAME_LENGTH: RangeInclusive<usize> = 3..=14;
-pub const NAME_REGEX: &str = "^[a-zA-Z][a-zA-Z0-9]*$";
+
+pub fn name_regex() -> &'static Regex {
+    regex!(r"^[a-zA-Z][a-zA-Z0-9]*$")
+}
 
 // Because askama makes it tricky to use a {% let player = foo.player %} and then an {% include "player_listing.html" %} to render a standardized player listing subtemplate, we set this up directly as an unescaped template that can be rendered into a parent template like {{foo.player.render().unwrap()|safe}}
 #[derive(Debug, Template)]
@@ -39,10 +41,7 @@ pub struct Player {
 
 impl Player {
     pub fn name_is_valid(name: &str) -> bool {
-        static RE: LazyLock<Regex> =
-            LazyLock::new(|| RegexBuilder::new(NAME_REGEX).build().unwrap());
-
-        NAME_LENGTH.contains(&name.len()) && RE.is_match(name)
+        NAME_LENGTH.contains(&name.len()) && name_regex().is_match(name)
     }
 
     pub fn set_name(txn: &Transaction, player_id: PlayerId, name: &str) -> Result<()> {

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -20,10 +20,9 @@ use askama_web::WebTemplate;
 use chrono::NaiveDateTime;
 use futures::prelude::*;
 use itertools::Itertools;
-use regex::{Regex, RegexBuilder};
+use regex::regex;
 use rusqlite::{Connection, OptionalExtension, Result as SqlResult};
 use serde::{Deserialize, Deserializer};
-use std::sync::LazyLock;
 use std::time::Duration;
 
 #[derive(Template, WebTemplate)]
@@ -255,13 +254,6 @@ pub async fn torikumi_page(
 }
 
 async fn fetch_sumo_db_torikumi(basho_id: BashoId, day: u8) -> Result<String> {
-    static RE: LazyLock<Regex> = LazyLock::new(|| {
-        RegexBuilder::new(r#"<div +class="simplecontent">\s*<pre>.*?\WMakuuchi\s+(.*?)</pre>"#)
-            .dot_matches_new_line(true)
-            .build()
-            .unwrap()
-    });
-
     let url = format!(
         "http://sumodb.sumogames.de/Results_text.aspx?b={}&d={}",
         basho_id.id(),
@@ -278,7 +270,8 @@ async fn fetch_sumo_db_torikumi(basho_id: BashoId, day: u8) -> Result<String> {
         .await?
         .text()
         .await?;
-    RE.captures(str.as_str())
+    regex!(r#"(?s)<div +class="simplecontent">\s*<pre>.*?\WMakuuchi\s+(.*?)</pre>"#)
+        .captures(str.as_str())
         .map(|cap| cap.get(1).unwrap().as_str().to_string())
         .ok_or_else(|| anyhow!("sumodb response did not match regex").into())
 }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,7 +23,7 @@
             required
             minlength="{{ player::NAME_LENGTH.start() }}"
             maxlength="{{ player::NAME_LENGTH.end() }}"
-            pattern="{{ player::NAME_REGEX }}"
+            pattern="{{ player::name_regex().as_str() }}"
             value="{{ base.player.as_ref().unwrap().name }}"
           />
           <span class="hint">(letters and numbers only)</span>


### PR DESCRIPTION
## Summary

- replace all three reusable Rust regex singletons with `regex!`
- expose the player-name regex through a shared accessor and use `Regex::as_str()` for the HTML validation pattern
- replace the SumoDB builder option with the equivalent inline `(?s)` flag
- remove all regex-related `LazyLock` and `RegexBuilder` boilerplate

This PR is stacked on #164 because `regex!` was introduced in regex 1.13.0.

Two unrelated `LazyLock` uses remain for the JST offset and `SUMO_API_DRY_RUN`; `LazyLock` is provided by the standard library rather than a Cargo dependency.

## Validation

- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`